### PR TITLE
fix: refactor fetch call to be in server n dumb default suggestion fix

### DIFF
--- a/src/@/components/competition-layout.tsx
+++ b/src/@/components/competition-layout.tsx
@@ -181,14 +181,14 @@ export function ResultLayout() {
 												<ul className="flex gap-2">
 													<Suspense fallback={<Skeleton />}>
 														{allocation.Attempts
-															? allocation.Attempts.map((at) => (
+															? allocation.Attempts.map((at, index) => (
 																	<li
 																		className={cn(
 																			allocation.Result === at.Line1 &&
 																				"bg-neutral-300/50!",
 																			"-my-1 flex flex-col rounded bg-neutral-600/50 px-2 py-1 text-sm",
 																		)}
-																		key={at.Line1}
+																		key={`${at.Line1}-${index}`}
 																	>
 																		<span>{at.Line1}</span>
 																		{at.Line2 && <span>{at.Line2}</span>}

--- a/src/app/competition/[slug]/page.tsx
+++ b/src/app/competition/[slug]/page.tsx
@@ -50,6 +50,7 @@ function butterParse(a: string): number {
 		return parseFloat(a);
 	}
 }
+// TODO: make the popover link not be hardcoded
 function ObsPopover({ slug }: { slug: string }) {
 	return (
 		<Popover>
@@ -274,14 +275,14 @@ export default async function Comp({
 														<ul className="flex gap-2">
 															<Suspense fallback={<Skeleton />}>
 																{allocation.Attempts
-																	? allocation.Attempts.map((at) => (
+																	? allocation.Attempts.map((at, index) => (
 																			<li
 																				className={cn(
 																					allocation.Result === at.Line1 &&
 																						"bg-neutral-300/50!",
 																					"-my-1 flex flex-col rounded bg-neutral-600/50 px-2 py-1 text-sm",
 																				)}
-																				key={at.Line1}
+																				key={`${at.Line1}-${index}`}
 																			>
 																				<span>{at.Line1}</span>
 																				{at.Line2 && <span>{at.Line2}</span>}
@@ -341,10 +342,10 @@ export default async function Comp({
 											<ul className="flex gap-2">
 												<Suspense fallback={<Skeleton />}>
 													{a.Attempts
-														? a.Attempts.map((at) => (
+														? a.Attempts.map((at, index) => (
 																<li
 																	className="-my-1 flex flex-col rounded bg-muted px-2 py-1 text-sm dark:bg-neutral-600/50"
-																	key={at.Line1}
+																	key={`${at.Line1}-${index}`}
 																>
 																	<span>{at.Line1}</span>
 																	{at.Line2 && <span>{at.Line2}</span>}

--- a/src/app/obs/[slug]/page.tsx
+++ b/src/app/obs/[slug]/page.tsx
@@ -91,13 +91,13 @@ export default function Obs({ params }: { params: { slug: string } }) {
 										{a.Attempts === null ? (
 											<p className="opacity-0">no</p>
 										) : (
-											a.Attempts?.map((at) => (
+											a.Attempts?.map((at, index) => (
 												<li
 													className={cn(
 														a.Result === at.Line1 && "bg-cyan-300/50!",
 														"flex min-w-[16.7%] flex-col px-1 py-2 even:bg-gray-200",
 													)}
-													key={at.Line1}
+													key={`${at.Line1}-${index}`}
 												>
 													<span>{at.Line1}</span>
 													{at.Line2 && <span>{at.Line2}</span>}

--- a/src/server/api/routers/competition.ts
+++ b/src/server/api/routers/competition.ts
@@ -1,15 +1,22 @@
 import { z } from "zod";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
-import type { Competition, CompetitionProperties } from "~/types/comp";
+import { tryCatch } from "~/shared/try-catch";
+import type {
+	Competition,
+	CompetitionList,
+	CompetitionProperties,
+	Events,
+} from "~/types/comp";
+
+const API_URL = "https://cached-public-api.tuloslista.com/live/v1";
 
 export const competitionsRouter = createTRPCRouter({
 	getAthletes: publicProcedure
 		.input(z.object({ compId: z.string() }))
 		.query(async ({ input }): Promise<Competition> => {
-			const res = await fetch(
-				`https://cached-public-api.tuloslista.com/live/v1/results/${input.compId}`,
-				{ cache: "no-store" },
-			);
+			const res = await fetch(`${API_URL}/results/${input.compId}`, {
+				cache: "no-store",
+			});
 			if (!res.ok) {
 				// This will activate the closest `error.js` Error Boundary
 				throw new Error("Failed to fetch data");
@@ -20,13 +27,36 @@ export const competitionsRouter = createTRPCRouter({
 		.input(z.object({ competitionDetailsId: z.string() }))
 		.query(async ({ input }): Promise<CompetitionProperties> => {
 			const res = await fetch(
-				`https://cached-public-api.tuloslista.com/live/v1/competition/${input.competitionDetailsId}/properties`,
+				`${API_URL}/competition/${input.competitionDetailsId}/properties`,
 			);
 			if (!res.ok) {
 				// This will activate the closest `error.js` Error Boundary
 				throw new Error("Failed to fetch data");
 			}
 			return res.json() as Promise<CompetitionProperties>;
+		}),
+	getCompetitions: publicProcedure.query(
+		async (): Promise<CompetitionList[]> => {
+			const { data, error } = await tryCatch(fetch(`${API_URL}/competition`));
+
+			if (error || !data) {
+				console.error("Error fetching comp data:", error);
+				return [];
+			}
+			return (await data.json()) as CompetitionList[];
+		},
+	),
+	getEvents: publicProcedure
+		.input(z.object({ compId: z.number() }))
+		.query(async ({ input }): Promise<Events> => {
+			const { data, error } = await tryCatch(
+				fetch(`${API_URL}/competition/${input.compId}`),
+			);
+			if (error || !data) {
+				console.error("Error fetching comp data:", error);
+				return {} as Events;
+			}
+			return (await data.json()) as Events;
 		}),
 
 	getAll: publicProcedure.query(() => {


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- search client fetch move to trpc call
  - refactoring search after move to trpc call
- fixed biome suggestion fix that did not want to use index for keys when mapped through data. now it is  `${s.ome}-${index}`.

---

💯
